### PR TITLE
Block category change

### DIFF
--- a/build/reviews-block/block.json
+++ b/build/reviews-block/block.json
@@ -4,7 +4,7 @@
   "name": "imagewize/reviews-block",
   "version": "0.1.0",
   "title": "Reviews Block",
-  "category": "widgets",
+  "category": "text",
   "icon": "star-filled",
   "description": "Display customer reviews in a three-column layout",
   "supports": {

--- a/src/reviews-block/block.json
+++ b/src/reviews-block/block.json
@@ -4,7 +4,7 @@
 	"name": "imagewize/reviews-block",
 	"version": "0.1.0",
 	"title": "Reviews Block",
-	"category": "widgets",
+	"category": "text",
 	"icon": "star-filled",
 	"description": "Display customer reviews in a three-column layout",
 	"supports": {


### PR DESCRIPTION
This pull request includes changes to the category of the `reviews-block` in two different files to ensure consistency across the project.

Category update for `reviews-block`:

* [`build/reviews-block/block.json`](diffhunk://#diff-c6a48fb5f94fcd6d51298e884e70d0136d23d88aeff2962c26b7b129b63e28a1L7-R7): Changed the category from "widgets" to "text".
* [`src/reviews-block/block.json`](diffhunk://#diff-2eeb9218a4d8b73c94d20ccfec4b0645342aa3f28fc9f6545f2d767af0e4df75L7-R7): Changed the category from "widgets" to "text".