### PR TITLE
Main Container Default Align full

### DIFF
--- a/build/reviews-block/block.json
+++ b/build/reviews-block/block.json
@@ -32,7 +32,7 @@
   "attributes": {
     "align": {
       "type": "string",
-      "default": "wide"
+      "default": "full"
     },
     "backgroundColor": {
       "type": "string",

--- a/src/reviews-block/block.json
+++ b/src/reviews-block/block.json
@@ -29,7 +29,7 @@
 	"attributes": {
 		"align": {
 			"type": "string",
-			"default": "wide"
+			"default": "full"
 		},
 		"backgroundColor": {
 			"type": "string",


### PR DESCRIPTION
This pull request includes changes to update the default alignment attribute in two JSON configuration files. The most important changes are:

* [`build/reviews-block/block.json`](diffhunk://#diff-c6a48fb5f94fcd6d51298e884e70d0136d23d88aeff2962c26b7b129b63e28a1L35-R35): Changed the default value of the `align` attribute from "wide" to "full".
* [`src/reviews-block/block.json`](diffhunk://#diff-2eeb9218a4d8b73c94d20ccfec4b0645342aa3f28fc9f6545f2d767af0e4df75L32-R32): Changed the default value of the `align` attribute from "wide" to "full".